### PR TITLE
Avoid reduced mode in DPO2k and similar scopes

### DIFF
--- a/PyTektronixScope/PyTektronixScope.py
+++ b/PyTektronixScope/PyTektronixScope.py
@@ -339,9 +339,10 @@ t0, DeltaT and data_start, data_stop args are mutually exculsive")
             if data_start is not None:
                 self.set_data_start(data_start)
             if data_stop is not None:
-                self.set_data_stop(data_stop) 
+                self.set_data_stop(data_stop)
             self.data_start = self.get_data_start()
             self.data_stop = self.get_data_stop()
+            self.write('dat:reso full')  # avoid reduced mode in MSO/DPO2k
         # Set the channel
         if channel is not None:
             self.set_data_source(channel)

--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,10 @@ This package can be used to record data from a Tektronix scope.
 Installation
 ============
 
-To install PyTektronixScope, download the package and run the command:: 
+To install PyTektronixScope, download the package, navigate to the directory in
+which you downloaded the repository, and run the command:: 
 
-  python setup.py install
+  pip install .
 
 You can also directly move the PyTektronixScope directory to a location
 that Python can import from.


### PR DESCRIPTION
Solves #19 

Moreover, I included a small change to the readme since directly calling `setup.py` has been deprecated for quite a long time now, see e.g. https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html